### PR TITLE
fix #6

### DIFF
--- a/hazm/Normalizer.py
+++ b/hazm/Normalizer.py
@@ -17,6 +17,8 @@ class Normalizer():
 		punc_after, punc_before = r'!:\.،؛؟»\]\)\}', r'«\[\(\{'
 		if character_refinement:
 			self.character_refinement_patterns = compile_patterns([
+				('"(.+)"', r'«\1»'),
+				("'(.+)'", r'«\1»'),
 				('([\d+]).([\d+])', r'\1٫\2'), # replace dot with momayez
 				(r'[ـ\r]', ''), # remove keshide, carriage returns
 				(r' +', ' '), # remove extra spaces


### PR DESCRIPTION
Add a pattern to convert `.` to `٫`. 
see [this](http://fa.wikipedia.org/wiki/%D9%85%D9%85%DB%8C%D8%B2_%D9%81%D8%A7%D8%B1%D8%B3%DB%8C)
