### PR TITLE
add functions to stem and lemmatize an iterable

### DIFF
--- a/hazm/Lemmatizer.py
+++ b/hazm/Lemmatizer.py
@@ -5,7 +5,11 @@ import codecs
 from .utils import default_words, default_verbs
 from .Stemmer import Stemmer
 from .WordTokenizer import WordTokenizer
-from itertools import imap, repeat
+try:
+    import itertools.imap as map
+except ImportError:
+    pass
+from itertools import repeat
 
 
 class Lemmatizer():
@@ -74,7 +78,7 @@ class Lemmatizer():
 		"""
 		Lemmatize iterable.
 		"""
-		return imap(self.lemmatize, iterable, repeat(pos))
+		return map(self.lemmatize, iterable, repeat(pos))
 
 	def conjugations(self, verb):
 		"""

--- a/hazm/Lemmatizer.py
+++ b/hazm/Lemmatizer.py
@@ -5,6 +5,7 @@ import codecs
 from .utils import default_words, default_verbs
 from .Stemmer import Stemmer
 from .WordTokenizer import WordTokenizer
+from itertools import imap, repeat
 
 
 class Lemmatizer():
@@ -68,6 +69,12 @@ class Lemmatizer():
 			return stem
 
 		return word
+
+	def ilemmatize(self, iterable, pos=''):
+		"""
+		Lemmatize iterable.
+		"""
+		return imap(self.lemmatize, iterable, repeat(pos))
 
 	def conjugations(self, verb):
 		"""

--- a/hazm/Stemmer.py
+++ b/hazm/Stemmer.py
@@ -31,3 +31,9 @@ class Stemmer(StemmerI):
 			word = word[:-len(end)] + 'ه'
 
 		return word
+
+	def istem(self, iterable):
+		"""
+		Stem an iterable.
+		"""
+		return map(self.stem, iterable)


### PR DESCRIPTION
Salam

# Why?

The main reason is you usaually want to stem and lemmatize not just a single word, but a collection of them. And the way you want to get these collections is through `word_tokenizer`. Currently you can do this:

``` python
stemmer = Stemmer()
stemmer.istem(word_tokenizer(sentence1))
# or
lemmatizer = Lemmatizer()
lemmatizer.ilemmatize(stemmer.istem(word_tokenizer(sentence1)))
```

I did not want to break things so I created separate functions called `istem` and `ilemmatize` (note the `i`).