### PR TITLE
fixed MAGHSURAH Y bug in normalizer

### DIFF
--- a/hazm/Normalizer.py
+++ b/hazm/Normalizer.py
@@ -15,7 +15,7 @@ class Normalizer(object):
 		self._affix_spacing = affix_spacing
 		self._token_based = token_based
 
-		translation_src, translation_dst = ' كي“”', ' کی""'
+		translation_src, translation_dst = ' ىكي“”', ' یکی""'
 		if persian_numbers:
 			translation_src += '0123456789%'
 			translation_dst += '۰۱۲۳۴۵۶۷۸۹٪'


### PR DESCRIPTION
in @trenditter bot (in twitter) we have faced a bug which showed two hashtags looking identical, after investigating the bug, I found that it was related to Normalizer class we used to homogenize same hashtags texts. some people used ی (with ascii code = 1609) instead of usual ی (with ascii code 1740), so I just simply added this to the translation dictionary :)