### PR TITLE
fix install problem in windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 
 from setuptools import setup
 
-setup(name='hazm',
+setup(
+	name='hazm',
 	version='0.5.3',
 	description='Python library for digesting Persian text.',
 	author='Alireza Nourian',
@@ -18,5 +19,6 @@ setup(name='hazm',
 		'Programming Language :: Python :: 3.6',
 		'License :: OSI Approved :: MIT License',
 	],
-	install_requires=['nltk==3.2.2', 'libwapiti>=0.2.1']
+	install_requires=['nltk==3.2.2', 'libwapiti>=0.2.1;platform_system!="Windows"'],
+	extras_require={'wapiti': ['libwapiti>=0.2.1']},
 )


### PR DESCRIPTION
<div dir="rtl">

برای رفع مشکل نصب

می شود تعریف کرد که موقع نصب در ویندوز کتابخانه libwapiti نصب نشود. [1, 2]

و در صورت نیاز به عنوان وابستگی دلخواه نصب شود. [3]

ارجاعات:

</div>

[1] https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies

[2] https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies

[3] https://pip.pypa.io/en/stable/reference/pip_install/#examples (بخش ۶)