### PR TITLE
Fix error prone

### DIFF
--- a/hazm/BijankhanReader.py
+++ b/hazm/BijankhanReader.py
@@ -17,7 +17,10 @@ class BijankhanReader():
 	[('اولین', 'ADJ'), ('سیاره', 'N'), ('خارج', 'ADJ'), ('از', 'PREP'), ('منظومه', 'N'), ('شمسی', 'ADJ'), ('دیده_شد', 'V'), ('.', 'PUNC')]
 	"""
 
-	def __init__(self, bijankhan_file, joined_verb_parts=True, pos_map=default_pos_map):
+	def __init__(self, bijankhan_file, joined_verb_parts=True, pos_map=None):
+		if pos_map is None:
+			pos_map = default_pos_map
+
 		self._bijankhan_file = bijankhan_file
 		self._joined_verb_parts = joined_verb_parts
 		self._pos_map = pos_map

--- a/hazm/Chunker.py
+++ b/hazm/Chunker.py
@@ -30,8 +30,8 @@ class Chunker(IOBTagger, ChunkParserI):
 	'[نامه ایشان NP] [را POSTP] [دریافت داشتم VP] .'
 	"""
 
-	def train(self, trees):
-		super(Chunker, self).train(map(tree2conlltags, trees))
+	def train(self, sentences):
+		super(Chunker, self).train(map(tree2conlltags, sentences))
 
 	def parse(self, sentence):
 		return next(self.parse_sents([sentence]))

--- a/hazm/DependencyParser.py
+++ b/hazm/DependencyParser.py
@@ -4,10 +4,10 @@ from __future__ import print_function, unicode_literals
 import os, codecs, tempfile
 from nltk.parse import DependencyGraph
 from nltk.parse.api import ParserI
-from nltk.parse.malt import MaltParser
+from nltk.parse.malt import MaltParser as NLTKMaltParser
 
 
-class MaltParser(MaltParser):
+class MaltParser(NLTKMaltParser):
 	"""
 	interfaces [MaltParser](http://www.maltparser.org/)
 	"""

--- a/hazm/PeykareReader.py
+++ b/hazm/PeykareReader.py
@@ -17,7 +17,7 @@ def coarse_pos_e(tags):
 
 	try:
 		return list(set(tags) & {'N', 'V', 'AJ', 'ADV', 'PRO', 'DET', 'P', 'POSTP', 'NUM', 'CONJ', 'PUNC', 'CL', 'INT', 'RES'})[0] + ('e' if 'EZ' in tags else '')
-	except:
+	except Exception:
 		return 'N'
 
 

--- a/hazm/SequenceTagger.py
+++ b/hazm/SequenceTagger.py
@@ -18,7 +18,10 @@ class SequenceTagger(TaggerI):
 	[[('من', 'PRO'), ('به', 'P'), ('مدرسه', 'N'), ('رفته_بودم', 'V'), ('.', 'PUNC')]]
 	"""
 
-	def __init__(self, patterns=[], **options):
+	def __init__(self, patterns=None, **options):
+		if patterns is None:
+			patterns = []
+
 		from wapiti import Model
 		self.model = Model(patterns='\n'.join(patterns), **options)
 

--- a/tests.py
+++ b/tests.py
@@ -40,7 +40,7 @@ class UnicodeOutputChecker(doctest.OutputChecker):
 		try:
 			got = got.decode('unicode-escape')
 			want = want.replace('آ', 'ا')  # decode issue
-		except:
+		except Exception:
 			pass
 
 		if type(want) == unicode:


### PR DESCRIPTION
1. We shouldn't use a mutable default value for optional parameters in functions. [1]
2. To override a method, we have to match that method signature.
3. In Python, a redefinition of functions, classes, and methods is allowed and overrides the original definition. This is confusing to readers and is therefore considered an error.
4. Catching exceptions should be as precise as possible. The type of exceptions that can be raised should be known in advance. Using a catch-all Exception instance defeats the purpose of knowing the type of error that occurred, and prohibits the use of tailored responses.

Links:
[1] https://docs.python.org/dev/faq/programming.html#why-are-default-values-shared-between-objects