### PR TITLE
fix endless loop in python3

### DIFF
--- a/hazm/WikipediaReader.py
+++ b/hazm/WikipediaReader.py
@@ -19,7 +19,7 @@ class WikipediaReader():
 		doc_pattern = re.compile(r'<doc id="(\d+)" url="([^\"]+)" title="([^\"]+)">')
 
 		doc = []
-		for line in iter(proc.stdout.readline, ''):
+		for line in iter(proc.stdout.readline, b''):
 			line = line.strip().decode('utf8')
 			if line:
 				doc.append(line)


### PR DESCRIPTION
in python3 the for loop in hazm/WikipediaReader.py becomes an endless loop.
in this version, this problem is fixed. this code is compatible with python2 and 3.