### PR TITLE
Fix some tokenization issues

### DIFF
--- a/hazm/WordTokenizer.py
+++ b/hazm/WordTokenizer.py
@@ -54,7 +54,7 @@ class WordTokenizer(TokenizerI):
 		self.emoji_repl = r'\g<0> '
 		self.id_pattern = re.compile(r'(?<![\w\._])(@[\w_]+)')
 		self.id_repl = r' ID '
-		self.link_pattern = re.compile(r'((https?|ftp):\/\/)?(?<!@)(([\w-]+\.)+((?![\d۰-۹])\w)+)[-\w@:%_\.\+\/~#?=&]*')
+		self.link_pattern = re.compile(r'((https?|ftp):\/\/)?(?<!@)(([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,})[-\w@:%_\.\+\/~#?=&]*')
 		self.link_repl = r' LINK '
 		self.email_pattern = re.compile(r'[a-zA-Z0-9\._\+-]+@([a-zA-Z0-9-]+\.)+[A-Za-z]{2,}')
 		self.email_repl = r' EMAIL '

--- a/hazm/WordTokenizer.py
+++ b/hazm/WordTokenizer.py
@@ -52,16 +52,19 @@ class WordTokenizer(TokenizerI):
 										u"\U0001F4CC\U0001F4CD"  # other emojis
 										"]", flags=re.UNICODE)
 		self.emoji_repl = r'\g<0> '
-		self.id_pattern = re.compile(r'([^\w\._]+)(@[\w_]+)')
-		self.id_repl = r'\1ID'
-		self.link_pattern = re.compile(r'((https?|ftp):\/\/)?(?<!@)([wW]{3}\.)?(([\w-]+)(\.(\w){2,})+([-\w@:%_\+\/~#?&]+)?)')
-		self.link_repl = r'LINK'
+		self.id_pattern = re.compile(r'(?<![\w\._])(@[\w_]+)')
+		self.id_repl = r' ID '
+		self.link_pattern = re.compile(r'((https?|ftp):\/\/)?(?<!@)(([\w-]+\.)+((?![\d۰-۹])\w)+)[-\w@:%_\.\+\/~#?=&]*')
+		self.link_repl = r' LINK '
 		self.email_pattern = re.compile(r'[a-zA-Z0-9\._\+-]+@([a-zA-Z0-9-]+\.)+[A-Za-z]{2,}')
-		self.email_repl = r'EMAIL'
-		self.number_int_pattern = re.compile(r'([^\.,\w]+)([\d۰-۹]+)([^\.,\w]+)')
-		self.number_int_repl = lambda m: m.group(1) + 'NUM'+ str(len(m.group(2))) + m.group(3)
-		self.number_float_pattern = re.compile(r'([^,\w]+)([\d۰-۹,]+[\.٫]{1}[\d۰-۹]+)([^,\w]+)')
-		self.number_float_repl = r'\1NUMF\3'
+		self.email_repl = r' EMAIL '
+
+		# '٫' is the decimal separator and '٬' is the thousands separator
+		self.number_int_pattern = re.compile(r'\b(?<![\d۰-۹][\.٫٬,])([\d۰-۹]+)(?![\.٫٬,][\d۰-۹])\b')
+		self.number_int_repl = lambda m: ' NUM' + str(len(m.group(1))) + ' '
+		self.number_float_pattern = re.compile(r'\b(?<!\.)([\d۰-۹,٬]+[\.٫٬]{1}[\d۰-۹]+)\b(?!\.)')
+		self.number_float_repl = r' NUMF '
+
 		self.hashtag_pattern = re.compile(r'\#([\S]+)')
 		# NOTE: python2.7 does not support unicodes with \w
 
@@ -96,12 +99,12 @@ class WordTokenizer(TokenizerI):
 
 		if self.separate_emoji:
 			text = self.emoji_pattern.sub(self.emoji_repl, text)
+		if self.replace_emails:
+			text = self.email_pattern.sub(self.email_repl, text)
 		if self.replace_links:
 			text = self.link_pattern.sub(self.link_repl, text)
 		if self.replace_IDs:
 			text = self.id_pattern.sub(self.id_repl, text)
-		if self.replace_emails:
-			text = self.email_pattern.sub(self.email_repl, text)
 		if self.replace_hashtags:
 			text = self.hashtag_pattern.sub(self.hashtag_repl, text)
 		if self.replace_numbers:


### PR DESCRIPTION
<p dir="rtl">
هنگام کار کردن با کلاس
WordTokenizer
به شکل زیر:
</p>

```
tokenizer = hazm.WordTokenizer(join_verb_parts=False, separate_emoji=True,
                               replace_links=True, replace_IDs=True,
                               replace_emails=True, replace_numbers=True)
```

<p dir="rtl">
چند مشکل مشاهده کردم که تعدادی از آن‌ها مربوط به قرار داشتن  توکن‌های عددی و
id
در ابتدا یا انتهای رشته بودند که
regex
های مربوط به آن‌ها نمی‌توانستند این توکن‌ها را تشخیص دهند.
هم‌چنین عددهای اعشاری و قسمت انتهایی ایمیل به عنوان لینک تشخیص داده می‌شود و در برخی موارد لینک هم به طور کامل جایگزین نمی‌شود.
برای بررسی این مشکل‌ها تست کیس‌های زیر را بررسی کردم:
</p>

<details>
  <summary dir="rtl">برای مشاهده کلیک کنید</summary>

```
print(f"{tokenizer.tokenize('123 ') = }")
print(f"{tokenizer.tokenize(' 123 ') = }")
print(f"{tokenizer.tokenize('123') = }")
print(f"{tokenizer.tokenize(' 12343434343433 ') = }")

print(f"{tokenizer.tokenize('۱۲۳ ') = }")
print(f"{tokenizer.tokenize(' ۱۲۳ ') = }")
print(f"{tokenizer.tokenize('۱۲۳') = }")
print(f"{tokenizer.tokenize(' ۱۱۲۳۲۳۴۲۴۱۲۲۳ ') = }")

print(f"{tokenizer.tokenize('123 -2') = }")
print(f"{tokenizer.tokenize('123+ 2') = }")
print(f"{tokenizer.tokenize('123*2') = }")

print(f"{tokenizer.tokenize('0.12') = }")
print(f"{tokenizer.tokenize('۰٫۱۲') = }")
print(f"{tokenizer.tokenize('۱۲٬۰۰۰') = }")
print(f"{tokenizer.tokenize('0.com') = }")
print(f"{tokenizer.tokenize('google.com') = }")
print(f"{tokenizer.tokenize('colab.research.google.com') = }")
print(f"{tokenizer.tokenize('http://abcd.com') = }")
print(f"{tokenizer.tokenize('example.com/index.html?q=hello%20world') = }")

print(f"{tokenizer.tokenize('abcd@gmail.com') = }")
print(f"{tokenizer.tokenize('@fardin') = }")
print(f"{tokenizer.tokenize(' @fardin') = }")
```

</details>

<p dir="rtl">
که برای کد کنونی این خروجی را ایجاد می‌کند:
</p>

```
tokenizer.tokenize('123 ') = ['123']
tokenizer.tokenize(' 123 ') = ['NUM3']
tokenizer.tokenize('123') = ['123']
tokenizer.tokenize(' 12343434343433 ') = ['NUM14']
tokenizer.tokenize('۱۲۳ ') = ['۱۲۳']
tokenizer.tokenize(' ۱۲۳ ') = ['NUM3']
tokenizer.tokenize('۱۲۳') = ['۱۲۳']
tokenizer.tokenize(' ۱۱۲۳۲۳۴۲۴۱۲۲۳ ') = ['NUM13']
tokenizer.tokenize('123 -2') = ['123', '-2']
tokenizer.tokenize('123+ 2') = ['123', '+', '2']
tokenizer.tokenize('123*2') = ['123', '*2']
tokenizer.tokenize('0.12') = ['LINK']
tokenizer.tokenize('۰٫۱۲') = ['۰٫۱۲']
tokenizer.tokenize('۱۲٬۰۰۰') = ['۱۲٬', '۰۰۰']
tokenizer.tokenize('0.com') = ['LINK']
tokenizer.tokenize('google.com') = ['LINK']
tokenizer.tokenize('colab.research.google.com') = ['LINK']
tokenizer.tokenize('http://abcd.com') = ['LINK']
tokenizer.tokenize('example.com/index.html?q=hello%20world') = ['LINK', '.', 'html', '?', 'q=hello%20world']
tokenizer.tokenize('abcd@gmail.com') = ['abcd@gLINK']
tokenizer.tokenize('@fardin') = ['@fardin']
tokenizer.tokenize(' @fardin') = ['ID']
```

<p dir="rtl">
برای حل مشکل قرار داشتن توکن در ابتدا یا انتهای رشته من به جای قاعده
<code dir="ltr">([^\w\._]+)</code>
از
lookahead
منفی
<code dir="ltr">(?&lt;![\w\._])</code>
استفاده کردم.
برای حل مشکل ایمیل هم مکان جایگزین کردن ایمیل را به قبل لینک بردم تا زودتر جایگزین شود.
قاعده
regex
آدرس
URL
را هم کمی تغییر دادم که کاراکترهای ? . & را هم شامل شود.
به دلیل این که در نام دامنه، بخش
top-level domain
نمی‌تواند شامل یک عدد باشد،
من در
regex
آدرس
URL
بخش انتهای دامنه را طوری قرار دادم که حاوی عدد نباشد و این گونه مشکل تشخیص لینک به جای عدد حل می‌شود.
علاوه بر این کاراکترهای جداساز اعشاری (٫) و جداسار هزارگان (٬) را هم اضافه کردم تا بتوانند جزیی از عدد تشخیص داده شوند.
</p>

<p dir="rtl">
با ایجاد این تغییرات، برای تست کیس‌های گفته شده در بالا خروجی زیر ایجاد می‌شود:
</p>

```
tokenizer.tokenize('123 ') = ['NUM3']
tokenizer.tokenize(' 123 ') = ['NUM3']
tokenizer.tokenize('123') = ['NUM3']
tokenizer.tokenize(' 12343434343433 ') = ['NUM14']
tokenizer.tokenize('۱۲۳ ') = ['NUM3']
tokenizer.tokenize(' ۱۲۳ ') = ['NUM3']
tokenizer.tokenize('۱۲۳') = ['NUM3']
tokenizer.tokenize(' ۱۱۲۳۲۳۴۲۴۱۲۲۳ ') = ['NUM13']
tokenizer.tokenize('123 -2') = ['NUM3', '-', 'NUM1']
tokenizer.tokenize('123+ 2') = ['NUM3', '+', 'NUM1']
tokenizer.tokenize('123*2') = ['NUM3', '*', 'NUM1']
tokenizer.tokenize('0.12') = ['NUMF']
tokenizer.tokenize('۰٫۱۲') = ['NUMF']
tokenizer.tokenize('۱۲٬۰۰۰') = ['NUMF']
tokenizer.tokenize('0.com') = ['LINK']
tokenizer.tokenize('google.com') = ['LINK']
tokenizer.tokenize('colab.research.google.com') = ['LINK']
tokenizer.tokenize('http://abcd.com') = ['LINK']
tokenizer.tokenize('example.com/index.html?q=hello%20world') = ['LINK']
tokenizer.tokenize('abcd@gmail.com') = ['EMAIL']
tokenizer.tokenize('@fardin') = ['ID']
tokenizer.tokenize(' @fardin') = ['ID']
```

<p dir="rtl">
البته مشکل دیگری که هم‌چنان وجود دارد، تشخیص رشته‌هایی است که درست فاصله‌گذاری نشده‌اند، مانند
"است.اما"،
که به عنوان لینک شناخته می‌شوند؛ به این دلیل که قاعده
<code dir="ltr">\w</code>
کاراکترهای الفبای فارسی را هم شامل می‌شود.
از طرف دیگر، دامنه‌های جدیدی که دارای پسوند غیر لاتین هستند مانند دامنه‌های ".ایران" هم وجود دارند که برای ان‌ها لازم است از
<code dir="ltr">\w</code>
استفاده شود. برای همین مطمئن نبودم که باید این قسمت را تغییر دهم یا نه.
</p>

<p dir="rtl">
از طرف دیگر این قاعده لینک‌های با آدرس آی‌پی مانند 192.168.1.1 و آدرس‌های رزرو شده مانند
localhost
را هم تشخیص نمی‌دهد؛
اما با توجه به این که این آدرس‌ها به ندرت در متن استفاده می‌شوند و پشتیبانی از آن‌ها
regex
را پیچیده می‌کند، به نظرم می‌توان از این موارد صرف نظر کرد.
</p>

<p dir="rtl">
علاوه بر این، تغییرات ایجاد شده را روی چند متن ویکیپدیا امتحان کردم و بجز مورد بالا مشکل خاص دیگری پیدا نکردم. 
</p>
